### PR TITLE
added the :aot key to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,4 +11,5 @@
                  [seesaw "1.4.3"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]
+  :aot  [nightcode.lein]
   :main nightcode.core)


### PR DESCRIPTION
This change enables `lein run' to work properly, because the nightcode.lein namespace needs to be AOT compiled before the project can be run.
