### PR TITLE
fix #28 - add command-line switch to use any skin and color theme

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [org.apache.bcel/bcel "5.2"]
                  [org.clojure/clojure "1.5.1"]
                  [org.clojure/core.incubator "0.1.3"]
+                 [org.clojure/tools.cli "0.2.4"]
                  [org.flatland/ordered "1.5.2"]
                  [org.lpetit/paredit.clj "0.19.3"]
                  [net.java.balloontip/balloontip "1.2.4"]

--- a/resources/light.xml
+++ b/resources/light.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE RSyntaxTheme SYSTEM "theme.dtd">
+
+<!--
+	Dark theme based off of Notepad++'s Obsidian theme.
+-->
+<RSyntaxTheme version="1.0">
+
+   <!-- Specify family="..." attribute to override system default monospaced. -->
+   <baseFont size="12"/>
+   
+   <!--  General editor colors. -->
+   <background color="d6cecb"/> <!-- 293134 -->
+   <caret color="3e343d"/> <!-- c1cbc2 -->
+   <selection bg="bfb1ae" roundedEdges="false"/> <!-- 404E51 -->
+   <currentLineHighlight color="d0c6c3" fade="false"/> <!-- 2F393C -->
+   <marginLine fg="c6bbb7"/> <!-- 394448 -->
+   <markAllHighlight color="947e76"/> <!-- TODO: Fix me --> <!-- 6b8189 -->
+   <markOccurrencesHighlight color="947e76" border="false"/> <!-- 6b8189 -->
+   <matchedBracket fg="6A8088" bg="947e76" highlightBoth="false" animate="true"/> <!-- 6b8189 -->
+   <hyperlinks fg="5f7d42"/> <!-- A082BD -->
+   <secondaryLanguages>
+      <language index="1" bg="ccbbaa"/> <!-- 334455 -->
+      <language index="2" bg="ddccdd"/> <!-- 223322 -->
+      <language index="3" bg="001f0f"/> <!-- ffe0f0 -->
+   </secondaryLanguages>
+   
+   <!-- Gutter styling. -->
+   <gutterBorder color="7e6965"/> <!-- 81969A -->
+   <lineNumbers fg="7e6965"/> <!-- 81969A -->
+   <foldIndicator fg="957f77" iconBg="2f383c"/> <!-- 6A8088 -->
+   <iconRowHeader activeLineRange="cc6600"/> <!-- 3399ff -->
+   
+   <!-- Syntax tokens. -->
+   <tokenStyles>
+      <style token="IDENTIFIER" fg="1f1d1b"/> <!-- E0E2E4 -->
+      <style token="RESERVED_WORD" fg="6c389c" bold="true"/> <!-- 93C763 -->
+      <style token="RESERVED_WORD_2" fg="6c389c" bold="true"/> <!-- 93C763 -->
+      <style token="ANNOTATION" fg="171d48"/> <!-- E8E2B7 -->
+      <style token="COMMENT_DOCUMENTATION" fg="938773"/> <!-- 6C788C -->
+      <style token="COMMENT_EOL" fg="998b84"/> <!-- 66747B -->
+      <style token="COMMENT_MULTILINE" fg="998b84"/> <!-- 66747B -->
+      <style token="COMMENT_KEYWORD" fg="516040"/> <!-- ae9fbf -->
+      <style token="COMMENT_MARKUP" fg="516040"/> <!-- ae9fbf -->
+      <style token="FUNCTION" fg="1f1d1b"/> <!-- E0E2E4 -->
+      <style token="DATA_TYPE" fg="98734e" bold="true"/> <!-- 678CB1 -->
+      <style token="LITERAL_BOOLEAN" fg="6c389c" bold="true"/> <!-- 93C763 -->
+      <style token="LITERAL_NUMBER_DECIMAL_INT" fg="0032dd"/> <!-- FFCD22 -->
+      <style token="LITERAL_NUMBER_FLOAT" fg="0032dd"/> <!-- FFCD22 -->
+      <style token="LITERAL_NUMBER_HEXADECIMAL" fg="0032dd"/> <!-- FFCD22 -->
+      <style token="LITERAL_STRING_DOUBLE_QUOTE" fg="1389ff"/> <!-- EC7600 -->
+      <style token="LITERAL_CHAR" fg="1389ff"/> <!-- EC7600 -->
+      <style token="LITERAL_BACKQUOTE" fg="1389ff"/> <!-- EC7600 -->
+      <style token="MARKUP_TAG_DELIMITER" fg="98734e"/> <!-- 678CB1 -->
+      <style token="MARKUP_TAG_NAME" fg="54402c"/> <!-- ABBFD3 -->
+      <style token="MARKUP_TAG_ATTRIBUTE" fg="4c4976"/> <!-- B3B689 -->
+      <style token="MARKUP_TAG_ATTRIBUTE_VALUE" fg="1e1d30"/> <!-- e1e2cf -->
+      <style token="MARKUP_PROCESSING_INSTRUCTION" fg="5f7d42"/> <!-- A082BD -->
+      <style token="MARKUP_CDATA" fg="516040"/> <!-- ae9fbf -->
+      <style token="OPERATOR" fg="171d48"/> <!-- E8E2B7 -->
+      <style token="PREPROCESSOR" fg="5f7d42"/> <!-- A082BD -->
+      <style token="REGEX" fg="2c68ba"/> <!-- d39745 -->
+      <style token="SEPARATOR" fg="171d48"/> <!-- E8E2B7 -->
+      <style token="VARIABLE" fg="516040" bold="true"/> <!-- ae9fbf -->
+      <style token="WHITESPACE" fg="1f1d1b"/> <!-- E0E2E4 -->
+      
+      <style token="ERROR_IDENTIFIER" fg="1f1d1b" bg="fb86f1"/> <!-- E0E2E4, 04790e -->
+      <style token="ERROR_NUMBER_FORMAT" fg="1f1d1b" bg="fb86f1"/> <!-- E0E2E4, 04790e -->
+      <style token="ERROR_STRING_DOUBLE" fg="1f1d1b" bg="fb86f1"/> <!-- E0E2E4, 04790e -->
+      <style token="ERROR_CHAR" fg="1f1d1b" bg="fb86f1"/> <!-- E0E2E4, 04790e -->
+   </tokenStyles>
+
+</RSyntaxTheme>

--- a/src/clojure/nightcode/core.clj
+++ b/src/clojure/nightcode/core.clj
@@ -1,5 +1,8 @@
 (ns nightcode.core
-  (:require [seesaw.core :as s]
+  (:require [clojure.java.io :as jio]
+            [clojure.string :as str]
+            [clojure.tools.cli :as cli]
+            [seesaw.core :as s]
             [nightcode.dialogs :as dialogs]
             [nightcode.editors :as editors]
             [nightcode.lein :as lein]
@@ -11,7 +14,17 @@
            [javax.swing.event TreeExpansionListener TreeSelectionListener]
            [javax.swing.tree TreeSelectionModel]
            [org.pushingpixels.substance.api SubstanceLookAndFeel]
-           [org.pushingpixels.substance.api.skin GraphiteSkin])
+           [org.pushingpixels.substance.api.skin GraphiteSkin]
+           [org.pushingpixels.substance.api.skin
+            ;; light skin classes
+            AutumnSkin BusinessSkin BusinessBlueSteelSkin BusinessBlackSteelSkin
+            CremeSkin CremeCoffeeSkin DustSkin DustCoffeeSkin GeminiSkin
+            MarinerSkin MistAquaSkin MistSilverSkin ModerateSkin
+            NebulaSkin NebulaBrickWallSkin SaharaSkin
+            ;; dark skin classes
+            ChallengerDeepSkin EmeraldDuskSkin
+            GraphiteSkin GraphiteGlassSkin GraphiteAquaSkin MagellanSkin 
+            RavenSkin TwilightSkin])
   (:gen-class))
 
 (defn get-project-pane
@@ -107,11 +120,91 @@
                           :divider-location 0.8
                           :resize-weight 0.5))))
 
+(defn make-skin-map []
+  {;; light skins
+   "autumn"               [(AutumnSkin.)             :light]
+   "business"             [(BusinessSkin.)           :light]
+   "business-blue-steel"  [(BusinessBlueSteelSkin.)  :light]
+   "business-black-steel" [(BusinessBlackSteelSkin.) :light]
+   "creme"                [(CremeSkin.)              :light]
+   "creme-coffee"         [(CremeCoffeeSkin.)        :light]
+   "dust"                 [(DustSkin.)               :light]
+   "dust-coffee"          [(DustCoffeeSkin.)         :light]
+   "gemini"               [(GeminiSkin.)             :light]
+   "light"                [(DustSkin.)               :light]  ; default light
+   "mariner"              [(MarinerSkin.)            :light]
+   "mist-aqua"            [(MistAquaSkin.)           :light]
+   "mist-silver"          [(MistSilverSkin.)         :light]
+   "moderate"             [(ModerateSkin.)           :light]
+   "nebula"               [(NebulaSkin.)             :light]
+   "nebula-brick-wall"    [(NebulaBrickWallSkin.)    :light]
+   "sahara"               [(SaharaSkin.)             :light]
+   ;; dark skins
+   "challenger-deep" [(ChallengerDeepSkin.) :dark]
+   "dark"            [(GraphiteSkin.)       :dark]  ; default dark
+   "emerald-dusk"    [(EmeraldDuskSkin.)    :dark]
+   "graphite"        [(GraphiteSkin.)       :dark]
+   "graphite-glass"  [(GraphiteGlassSkin.)  :dark]
+   "graphite-aqua"   [(GraphiteAquaSkin.)   :dark]
+   "magellan"        [(MagellanSkin.)       :dark]
+   "raven"           [(RavenSkin.)          :dark]
+   "twilight"        [(TwilightSkin.)       :dark]})
+
+(defn abort
+  [& msgs]
+  (binding [*out* *err*]
+    (apply println msgs)
+    (System/exit 1)))
+
+(defn show-help [help-str]
+  (let [shade-names (fn [shade skin-map]
+                      (str/join ", " (->> skin-map
+                                       (filter #(= shade (second (second %))))
+                                       (map first)
+                                       sort)))
+        skin-map (make-skin-map)]
+    (abort
+      (format "%s
+Dark skin names: %s
+Light skin names: %s
+"
+              help-str
+              (shade-names :dark skin-map)
+              (shade-names :light skin-map)))))
+
+(defn parse-args
+  [args]
+  (let [[opts tokens help-str] (cli/cli args
+                                        ["-h" "--help" :flag true]
+                                        ["-s" "--skin-name" :default "dark"]
+                                        ["-t" "--theme-resource"])
+        skin-map (make-skin-map)]
+    (cond
+      (:help opts) (show-help help-str)
+      (and (:theme-resource opts)
+           (not (:skin-name opts))) (abort "ERROR: Must specify skin with theme")
+      (if-let [skin-name (:skin-name opts)]
+        (not (contains? skin-map skin-name))) (abort "ERROR: Invalid skin-name")
+      (if-let [th-res (:theme-resource opts)]
+        (nil? (jio/resource th-res))) (abort "ERROR: Not found in classpath:"
+                                             (:theme-resource opts))
+      :otherwise (let [skin-name (:skin-name opts)
+                       [skin-obj shade] (get skin-map skin-name)]
+                   (assoc opts
+                          :shade shade
+                          :skin-object skin-obj
+                          :theme-resource (or (:theme-resource opts)
+                                              (if (= :light shade)
+                                                "light.xml" "dark.xml")))))))
+
+
 (defn -main
   "Launches the main window."
   [& args]
   (s/native!)
-  (SubstanceLookAndFeel/setSkin (GraphiteSkin.))
+  (let [{:keys [shade skin-object theme-resource]} (parse-args args)]
+    (when theme-resource (reset! editors/theme-resource theme-resource))
+    (SubstanceLookAndFeel/setSkin skin-object))
   (s/invoke-later
     ; create and show the frame
     (reset! ui/ui-root

--- a/src/clojure/nightcode/editors.clj
+++ b/src/clojure/nightcode/editors.clj
@@ -31,6 +31,8 @@
 (def tabs (atom nil))
 (def ^:dynamic *reorder-tabs?* true)
 
+(def theme-resource (atom "dark.xml"))
+
 (defn get-editor
   [path]
   (when (contains? @editors path)
@@ -410,8 +412,8 @@
                                 (update-buttons text-group text-area))
                               (removeUpdate [this e]
                                 (update-buttons text-group text-area))))
-      ; load the dark theme
-      (-> (io/resource "dark.xml")
+      ; load the appropriate (default: dark) theme
+      (-> (io/resource @theme-resource)
           io/input-stream
           Theme/load
           (.apply text-area))


### PR DESCRIPTION
This PR fixes #28 non-intrusively, wherein a command-line switch can override the skin and theme resource used by Nightcode. I have added a `light.xml` resource by XORing all color values with 0xFFFFFF. Also, it automatically chooses the right theme resource as per the skin name. Build _uberjar_ and execute with `-h` switch to see the command-line options.

A screenshot with the common light theme is here: http://imagebin.org/277367

_Note:_ Specifying the theme resource is hard for the user due to Java's handling of executable JAR files. User must construct the classpath and invoke `nightcode.core` in order to specify the theme resource.
