### PR TITLE
factor out CLI args handling in a separate namespace

### DIFF
--- a/src/clojure/nightcode/cli_args.clj
+++ b/src/clojure/nightcode/cli_args.clj
@@ -1,0 +1,92 @@
+(ns nightcode.cli-args
+  (:require [clojure.java.io :as jio]
+            [clojure.string :as str]
+            [clojure.tools.cli :as cli])
+  (:import [org.pushingpixels.substance.api.skin
+            ;; light skin classes
+            AutumnSkin BusinessSkin BusinessBlueSteelSkin BusinessBlackSteelSkin
+            CremeSkin CremeCoffeeSkin DustSkin DustCoffeeSkin GeminiSkin
+            MarinerSkin MistAquaSkin MistSilverSkin ModerateSkin
+            NebulaSkin NebulaBrickWallSkin SaharaSkin
+            ;; dark skin classes
+            ChallengerDeepSkin EmeraldDuskSkin
+            GraphiteSkin GraphiteGlassSkin GraphiteAquaSkin MagellanSkin 
+            RavenSkin TwilightSkin]))
+
+(defn make-skin-map []
+  {;; light skins
+   "autumn"               [(AutumnSkin.)             :light]
+   "business"             [(BusinessSkin.)           :light]
+   "business-blue-steel"  [(BusinessBlueSteelSkin.)  :light]
+   "business-black-steel" [(BusinessBlackSteelSkin.) :light]
+   "creme"                [(CremeSkin.)              :light]
+   "creme-coffee"         [(CremeCoffeeSkin.)        :light]
+   "dust"                 [(DustSkin.)               :light]
+   "dust-coffee"          [(DustCoffeeSkin.)         :light]
+   "gemini"               [(GeminiSkin.)             :light]
+   "light"                [(DustSkin.)               :light]  ; default light
+   "mariner"              [(MarinerSkin.)            :light]
+   "mist-aqua"            [(MistAquaSkin.)           :light]
+   "mist-silver"          [(MistSilverSkin.)         :light]
+   "moderate"             [(ModerateSkin.)           :light]
+   "nebula"               [(NebulaSkin.)             :light]
+   "nebula-brick-wall"    [(NebulaBrickWallSkin.)    :light]
+   "sahara"               [(SaharaSkin.)             :light]
+   ;; dark skins
+   "challenger-deep" [(ChallengerDeepSkin.) :dark]
+   "dark"            [(GraphiteSkin.)       :dark]  ; default dark
+   "emerald-dusk"    [(EmeraldDuskSkin.)    :dark]
+   "graphite"        [(GraphiteSkin.)       :dark]
+   "graphite-glass"  [(GraphiteGlassSkin.)  :dark]
+   "graphite-aqua"   [(GraphiteAquaSkin.)   :dark]
+   "magellan"        [(MagellanSkin.)       :dark]
+   "raven"           [(RavenSkin.)          :dark]
+   "twilight"        [(TwilightSkin.)       :dark]})
+
+(defn abort
+  [& msgs]
+  (binding [*out* *err*]
+    (apply println msgs)
+    (System/exit 1)))
+
+(defn show-help [help-str]
+  (let [shade-names (fn [shade skin-map]
+                      (str/join ", " (->> skin-map
+                                       (filter #(= shade (second (second %))))
+                                       (map first)
+                                       sort)))
+        skin-map (make-skin-map)]
+    (abort
+      (format "%s
+Dark skin names: %s
+Light skin names: %s
+"
+              help-str
+              (shade-names :dark skin-map)
+              (shade-names :light skin-map)))))
+
+(defn parse-args
+  [args]
+  (let [[opts tokens help-str] (cli/cli args
+                                        ["-h" "--help" :flag true]
+                                        ["-s" "--skin-name" :default "dark"]
+                                        ["-t" "--theme-resource"])
+        skin-map (make-skin-map)]
+    (cond
+      (or (not (:skin-name opts))
+          (:help opts))             (show-help help-str)
+      (and (:theme-resource opts)
+           (not (:skin-name opts))) (abort "ERROR: Must specify skin with theme")
+      (if-let [skin-name (:skin-name opts)]
+        (not (contains? skin-map skin-name))) (abort "ERROR: Invalid skin-name")
+      (if-let [th-res (:theme-resource opts)]
+        (nil? (jio/resource th-res))) (abort "ERROR: Not found in classpath:"
+                                             (:theme-resource opts))
+      :otherwise (let [skin-name (:skin-name opts)
+                       [skin-obj shade] (get skin-map skin-name)]
+                   (assoc opts
+                          :shade shade
+                          :skin-object skin-obj
+                          :theme-resource (or (:theme-resource opts)
+                                              (if (= :light shade)
+                                                "light.xml" "dark.xml")))))))

--- a/src/clojure/nightcode/core.clj
+++ b/src/clojure/nightcode/core.clj
@@ -1,8 +1,6 @@
 (ns nightcode.core
-  (:require [clojure.java.io :as jio]
-            [clojure.string :as str]
-            [clojure.tools.cli :as cli]
-            [seesaw.core :as s]
+  (:require [seesaw.core :as s]
+            [nightcode.cli-args :as cli-args]
             [nightcode.dialogs :as dialogs]
             [nightcode.editors :as editors]
             [nightcode.lein :as lein]
@@ -14,17 +12,7 @@
            [javax.swing.event TreeExpansionListener TreeSelectionListener]
            [javax.swing.tree TreeSelectionModel]
            [org.pushingpixels.substance.api SubstanceLookAndFeel]
-           [org.pushingpixels.substance.api.skin GraphiteSkin]
-           [org.pushingpixels.substance.api.skin
-            ;; light skin classes
-            AutumnSkin BusinessSkin BusinessBlueSteelSkin BusinessBlackSteelSkin
-            CremeSkin CremeCoffeeSkin DustSkin DustCoffeeSkin GeminiSkin
-            MarinerSkin MistAquaSkin MistSilverSkin ModerateSkin
-            NebulaSkin NebulaBrickWallSkin SaharaSkin
-            ;; dark skin classes
-            ChallengerDeepSkin EmeraldDuskSkin
-            GraphiteSkin GraphiteGlassSkin GraphiteAquaSkin MagellanSkin 
-            RavenSkin TwilightSkin])
+           [org.pushingpixels.substance.api.skin GraphiteSkin])
   (:gen-class))
 
 (defn get-project-pane
@@ -120,91 +108,13 @@
                           :divider-location 0.8
                           :resize-weight 0.5))))
 
-(defn make-skin-map []
-  {;; light skins
-   "autumn"               [(AutumnSkin.)             :light]
-   "business"             [(BusinessSkin.)           :light]
-   "business-blue-steel"  [(BusinessBlueSteelSkin.)  :light]
-   "business-black-steel" [(BusinessBlackSteelSkin.) :light]
-   "creme"                [(CremeSkin.)              :light]
-   "creme-coffee"         [(CremeCoffeeSkin.)        :light]
-   "dust"                 [(DustSkin.)               :light]
-   "dust-coffee"          [(DustCoffeeSkin.)         :light]
-   "gemini"               [(GeminiSkin.)             :light]
-   "light"                [(DustSkin.)               :light]  ; default light
-   "mariner"              [(MarinerSkin.)            :light]
-   "mist-aqua"            [(MistAquaSkin.)           :light]
-   "mist-silver"          [(MistSilverSkin.)         :light]
-   "moderate"             [(ModerateSkin.)           :light]
-   "nebula"               [(NebulaSkin.)             :light]
-   "nebula-brick-wall"    [(NebulaBrickWallSkin.)    :light]
-   "sahara"               [(SaharaSkin.)             :light]
-   ;; dark skins
-   "challenger-deep" [(ChallengerDeepSkin.) :dark]
-   "dark"            [(GraphiteSkin.)       :dark]  ; default dark
-   "emerald-dusk"    [(EmeraldDuskSkin.)    :dark]
-   "graphite"        [(GraphiteSkin.)       :dark]
-   "graphite-glass"  [(GraphiteGlassSkin.)  :dark]
-   "graphite-aqua"   [(GraphiteAquaSkin.)   :dark]
-   "magellan"        [(MagellanSkin.)       :dark]
-   "raven"           [(RavenSkin.)          :dark]
-   "twilight"        [(TwilightSkin.)       :dark]})
-
-(defn abort
-  [& msgs]
-  (binding [*out* *err*]
-    (apply println msgs)
-    (System/exit 1)))
-
-(defn show-help [help-str]
-  (let [shade-names (fn [shade skin-map]
-                      (str/join ", " (->> skin-map
-                                       (filter #(= shade (second (second %))))
-                                       (map first)
-                                       sort)))
-        skin-map (make-skin-map)]
-    (abort
-      (format "%s
-Dark skin names: %s
-Light skin names: %s
-"
-              help-str
-              (shade-names :dark skin-map)
-              (shade-names :light skin-map)))))
-
-(defn parse-args
-  [args]
-  (let [[opts tokens help-str] (cli/cli args
-                                        ["-h" "--help" :flag true]
-                                        ["-s" "--skin-name" :default "dark"]
-                                        ["-t" "--theme-resource"])
-        skin-map (make-skin-map)]
-    (cond
-      (:help opts) (show-help help-str)
-      (and (:theme-resource opts)
-           (not (:skin-name opts))) (abort "ERROR: Must specify skin with theme")
-      (if-let [skin-name (:skin-name opts)]
-        (not (contains? skin-map skin-name))) (abort "ERROR: Invalid skin-name")
-      (if-let [th-res (:theme-resource opts)]
-        (nil? (jio/resource th-res))) (abort "ERROR: Not found in classpath:"
-                                             (:theme-resource opts))
-      :otherwise (let [skin-name (:skin-name opts)
-                       [skin-obj shade] (get skin-map skin-name)]
-                   (assoc opts
-                          :shade shade
-                          :skin-object skin-obj
-                          :theme-resource (or (:theme-resource opts)
-                                              (if (= :light shade)
-                                                "light.xml" "dark.xml")))))))
-
-
 (defn -main
   "Launches the main window."
   [& args]
   (s/native!)
-  (let [{:keys [shade skin-object theme-resource]} (parse-args args)]
+  (let [{:keys [shade skin-object theme-resource]} (cli-args/parse-args args)]
     (when theme-resource (reset! editors/theme-resource theme-resource))
-    (SubstanceLookAndFeel/setSkin skin-object))
+    (SubstanceLookAndFeel/setSkin (or skin-object (GraphiteSkin.))))
   (s/invoke-later
     ; create and show the frame
     (reset! ui/ui-root


### PR DESCRIPTION
As @oakes observed in his comment in #41, this PR factors out the CLI args handling in a separate namespace. It also fixes a minor corner-case where invoking the standalone JAR with simply `-s` throws a cryptic exception instead of printing an error message.
