### PR TITLE
avoid lein warning 'Implicit AOT of :main'

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,5 +23,5 @@
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
   :aot [clojure.main nightcode.core nightcode.lein]
-  :main nightcode.Main
+  :main ^:skip-aot nightcode.Main
   :manifest {"SplashScreen-Image" "loading.gif"})


### PR DESCRIPTION
When building jar/uberjar, `lein` warns `Implicit AOT of :main will be removed in Leiningen 3.0.0`. This PR fixes that by specifying that AOT is not required for `:main`.
