### PR TITLE
fix #48 by detecting file type using jmimemagic Java library

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,6 @@
                  [com.fifesoft/autocomplete "2.5.0"]
                  [com.fifesoft/rsyntaxtextarea "2.5.0"]
                  [compliment "0.0.3"]
-                 [jmimemagic "0.1.2"]
                  [leiningen "2.3.4"]
                  [lein-ancient "0.5.4" :exclusions [clj-aws-s3]]
                  [lein-cljsbuild "1.0.0"]

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,4 +1,0 @@
-log4j.rootLogger=WARN, console
-log4j.appender.console=org.apache.log4j.ConsoleAppender 
-log4j.appender.console.layout=org.apache.log4j.PatternLayout 
-log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
This PR uses [jMimeMagic](https://github.com/arimus/jmimemagic) to detect file type if the file extension is not one among the white-listed types. Also adds `.cljx` and `.edn` to known Clojure file extensions.
