### PR TITLE
fix #51 - show unsaved filenames in exit confirmation dialog

### DIFF
--- a/resources/values/strings.xml
+++ b/resources/values/strings.xml
@@ -37,6 +37,7 @@
   <string name="project_clj_required">You need a project.clj file to build this project.</string>
   <string name="create_project_clj">Create project.clj</string>
   <string name="continue">Continue</string>
+  <string name="unsaved_confirm">You have unsaved files!</string>
   <string name="quit_confirm">Are you sure you want to quit?</string>
   <string name="quit">Quit</string>
 

--- a/src/clojure/nightcode/core.clj
+++ b/src/clojure/nightcode/core.clj
@@ -110,9 +110,12 @@
 
 (defn confirm-exit-app
   []
-  (if (dialogs/show-shut-down-dialog)
-    (System/exit 0)
-    true))
+  (let [unsaved-paths (->> (keys @editors/editors)
+                           (filter editors/is-unsaved?)
+                           doall)]
+    (if (dialogs/show-shut-down-dialog unsaved-paths)
+      (System/exit 0)
+      true)))
 
 (defn -main
   "Launches the main window."

--- a/src/clojure/nightcode/dialogs.clj
+++ b/src/clojure/nightcode/dialogs.clj
@@ -1,5 +1,6 @@
 (ns nightcode.dialogs
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [nightcode.utils :as utils]
             [seesaw.core :as s]
             [seesaw.icon :as icon])
@@ -102,8 +103,13 @@
         s/show!)))
 
 (defn show-shut-down-dialog
-  []
-  (-> (s/dialog :content (utils/get-string :quit_confirm)
+  [unsaved-paths]
+  (-> (s/dialog :content (str (when (seq unsaved-paths)
+                                (str (utils/get-string :unsaved_confirm)
+                                     \newline \newline
+                                     (str/join \newline unsaved-paths)
+                                     \newline \newline))
+                              (utils/get-string :quit_confirm))
                 :options [(s/button :text (utils/get-string :quit)
                                     :listen [:action
                                              #(s/return-from-dialog % true)])


### PR DESCRIPTION
This PR shows unsaved file names in the exit confirmation dialog box. Note that it does not solve the _visual cue_ issue mentioned in the bug report.
