### PR TITLE
treat user-specified theme resource as filename

### DIFF
--- a/src/clojure/nightcode/cli_args.clj
+++ b/src/clojure/nightcode/cli_args.clj
@@ -77,16 +77,18 @@ Light skin names: %s
           (:help opts))             (show-help help-str)
       (and (:theme-resource opts)
            (not (:skin-name opts))) (abort "ERROR: Must specify skin with theme")
-      (if-let [skin-name (:skin-name opts)]
+      (when-let [skin-name (:skin-name opts)]
         (not (contains? skin-map skin-name))) (abort "ERROR: Invalid skin-name")
-      (if-let [th-res (:theme-resource opts)]
-        (nil? (jio/resource th-res))) (abort "ERROR: Not found in classpath:"
-                                             (:theme-resource opts))
+      (when-let [th-res (:theme-resource opts)]
+        (not (.isFile (jio/file th-res)))) (abort "ERROR: Not such file found:"
+                                                  (:theme-resource opts))
       :otherwise (let [skin-name (:skin-name opts)
                        [skin-obj shade] (get skin-map skin-name)]
                    (assoc opts
                           :shade shade
                           :skin-object skin-obj
-                          :theme-resource (or (:theme-resource opts)
-                                              (if (= :light shade)
-                                                "light.xml" "dark.xml")))))))
+                          :theme-resource (or (when-let [filename (:theme-resource opts)]
+                                                (jio/file filename))
+                                              (-> (= :light shade)
+                                                (if "light.xml" "dark.xml")
+                                                jio/resource)))))))

--- a/src/clojure/nightcode/editors.clj
+++ b/src/clojure/nightcode/editors.clj
@@ -32,7 +32,7 @@
 (def tabs (atom nil))
 (def ^:dynamic *reorder-tabs?* true)
 
-(def theme-resource (atom "dark.xml"))
+(def theme-resource (atom (io/resource "dark.xml")))
 
 (defn get-editor
   [path]
@@ -472,7 +472,7 @@
                               (removeUpdate [this e]
                                 (update-buttons! text-group text-area))))
       ; load the appropriate (default: dark) theme
-      (-> (io/resource @theme-resource)
+      (-> @theme-resource
           io/input-stream
           Theme/load
           (.apply text-area))


### PR DESCRIPTION
As of Nightcode 0.2.6 when a user specifies theme resource via command-line, it is considered a resource on classpath which is counter-intuitive because the user would not have the file inside the Nightcode JAR file.

This PR makes Nightcode treat the user-specified theme resource as a filename, and complains if the file is not found.
