### PR TITLE
Set application icon to logo_splash.png

### DIFF
--- a/src/clojure/nightcode/core.clj
+++ b/src/clojure/nightcode/core.clj
@@ -10,7 +10,8 @@
             [nightcode.ui :as ui]
             [nightcode.utils :as utils]
             [nightcode.window :as window]
-            [seesaw.core :as s])
+            [seesaw.core :as s]
+            [seesaw.icon :as i])
   (:gen-class))
 
 (defn create-window-content
@@ -80,9 +81,8 @@
 (def apple-set-icon-thunk
   `(do
      (import 'com.apple.eawt.Application)
-     (import 'javax.swing.ImageIcon)
      (-> (Application/getApplication)
-       (.setDockIconImage (.getImage (ImageIcon. "logo_splash.png"))))))
+       (.setDockIconImage (.getImage (i/icon "logo_splash.png"))))))
 
 (defn -main
   "Launches the main window."


### PR DESCRIPTION
Currently Nightcode app icon is displayed as the Java icon, which is generic and boring. This PR sets the app icon to the `logo_splash.png` image. Tested on Linux and OS X Lion. OS X needs special handling as described at the reference URL below.

Reference: http://stackoverflow.com/questions/11253772/setting-the-default-application-icon-image-in-java-swing-on-os-x
