### PR TITLE
add mono compatibility to .NET project.clj template

### DIFF
--- a/src/clojure/leiningen/new/dotnet_clojure/project.clj
+++ b/src/clojure/leiningen/new/dotnet_clojure/project.clj
@@ -3,7 +3,7 @@
   :dependencies []
   :warn-on-reflection true
   :plugins [[lein-clr "0.2.1"]]
-  :clr {:cmd-templates {:clj-exe [["target" "clr" "lib" "{{internal-dir}}" %1]]
+  :clr {:cmd-templates {:clj-exe [[?PATH "mono"] ["target" "clr" "lib" "{{internal-dir}}" %1]]
                         :clj-zip [".." ".." ".." "{{zip-path}}"]
                         :unzip ["jar" "xf" %2]}
         :deps-cmds [[:unzip "" :clj-zip]]


### PR DESCRIPTION
The `[?PATH "mono"]` expression searches the executable `mono` in PATH, and uses it to execute the remaining command. This makes the project usable with Mono on *nix systems and Windows.
