### PR TITLE
uses the robovm path as starting point for dialog

### DIFF
--- a/src/clojure/nightcode/builders.clj
+++ b/src/clojure/nightcode/builders.clj
@@ -38,7 +38,7 @@
   [& _]
   (if (sandbox/get-dir)
     (dialogs/show-simple-dialog! (utils/get-string :sandbox-apology))
-    (when-let [d (dialogs/show-open-dialog! (utils/read-pref :android-sdk))]
+    (when-let [d (dialogs/show-open-dialog! (utils/read-pref :robovm))]
       (utils/write-pref! :robovm (.getCanonicalPath d))
       (show-builder! (ui/get-project-path @ui/tree-selection)))))
 


### PR DESCRIPTION
just a minor fix, it was showing the android-sdk path as the initial path for the robovm directory.
