### PR TITLE
more options to setup window size and panel layout on command line

### DIFF
--- a/src/clojure/nightcode/cli_args.clj
+++ b/src/clojure/nightcode/cli_args.clj
@@ -70,6 +70,8 @@ Light skin names: %s
   (let [[opts tokens help-str] (cli/cli args
                                         ["-h" "--help" :flag true]
                                         ["-s" "--skin-name" :default "dark"]
+                                        ["-f" "--fullscreen" :default false :flag true]
+                                        ["-p" "--panel" :default "vertical"]
                                         ["-t" "--theme-resource"])
         skin-map (make-skin-map)]
     (cond

--- a/src/clojure/nightcode/core.clj
+++ b/src/clojure/nightcode/core.clj
@@ -1,6 +1,7 @@
 (ns nightcode.core
   (:require [nightcode.builders :as builders]
             [nightcode.dialogs :as dialogs]
+            [nightcode.cli-args :as cli-args]
             [nightcode.editors :as editors]
             [nightcode.logcat :as logcat]
             [nightcode.projects :as projects]
@@ -15,7 +16,7 @@
 
 (defn create-window-content
   "Returns the entire window with all panes."
-  []
+  [args]
   (let [console (editors/create-console "*repl*")
         one-touch! #(doto % (.setOneTouchExpandable true))]
     (one-touch!
@@ -23,37 +24,50 @@
         (one-touch!
           (s/top-bottom-split (projects/create-pane console)
                               (repl/create-pane console)
-                              :divider-location 0.8
+                              :divider-location 0.7
                               :resize-weight 0.5))
-        (one-touch!
-          (s/top-bottom-split (editors/create-pane)
+          (one-touch!
+            (if (= (args :panel) "horizontal")
+              (s/left-right-split 
+                              (editors/create-pane)
                               (builders/create-pane)
-                              :divider-location 0.8
-                              :resize-weight 0.5))
+                              :divider-location 0.5
+                              :resize-weight 0.5)
+              (s/top-bottom-split 
+                (editors/create-pane)
+                              (builders/create-pane)
+                              :divider-location 0.7
+                              :resize-weight 0.5)))
         :divider-location 0.32
         :resize-weight 0))))
 
 (defn create-window
   "Creates the main window."
-  []
+  [args]
+  (let [
+    screen (.getScreenSize (java.awt.Toolkit/getDefaultToolkit))
+    height (if (args :fullscreen) (.getHeight screen) 768)
+    width  (if (args :fullscreen) (.getWidth screen) 1242)
+      ]
   (doto (s/frame :title (str "Nightcode " (or (some-> "nightcode.core"
                                                       utils/get-project
                                                       (nth 2))
                                               "beta"))
-                 :content (create-window-content)
-                 :width 1242
-                 :height 768
+                 :content (create-window-content args)
+                 :width width
+                 :height height
                  :icon "logo_launcher.png"
                  :on-close :nothing)
     ; set various window properties
     window/enable-full-screen!
-    window/add-listener!))
+    window/add-listener!)))
 
 (defn -main
   "Launches the main window."
   [& args]
+  (let [parsed-args (cli-args/parse-args args)]
   (window/set-icon! "logo_launcher.png")
-  (window/set-theme! args)
+  (window/set-theme! parsed-args)
   (sandbox/set-home!)
   (sandbox/create-profiles-clj!)
   (sandbox/read-file-permissions!)
@@ -79,6 +93,6 @@
           ; else
           false)))
     ; create and show the frame
-    (s/show! (reset! ui/root (create-window)))
+    (s/show! (reset! ui/root (create-window parsed-args)))
     ; initialize the project pane
-    (ui/update-project-tree!)))
+    (ui/update-project-tree!))))

--- a/src/clojure/nightcode/window.clj
+++ b/src/clojure/nightcode/window.clj
@@ -1,6 +1,5 @@
 (ns nightcode.window
-  (:require [nightcode.cli-args :as cli-args]
-            [nightcode.dialogs :as dialogs]
+  (:require [nightcode.dialogs :as dialogs]
             [nightcode.editors :as editors]
             [nightcode.file-browser :as file-browser]
             [nightcode.shortcuts :as shortcuts]
@@ -17,7 +16,7 @@
   "Sets the theme based on the command line arguments."
   [args]
   (s/native!)
-  (let [{:keys [shade skin-object theme-resource]} (cli-args/parse-args args)]
+  (let [{:keys [shade skin-object theme-resource]} args]
     (when theme-resource (reset! editors/theme-resource theme-resource))
     (SubstanceLookAndFeel/setSkin (or skin-object (GraphiteSkin.)))))
 


### PR DESCRIPTION
I have added 2 options when starting nightcode:
- one to setup the screensize to make better use of the screen resolution (-f)
- another to do the layout in a left right manner when using wide width (-p) 

Let me know what you think. 
