### PR TITLE
proposed patch for #61

### DIFF
--- a/src/clojure/nightcode/shortcuts.clj
+++ b/src/clojure/nightcode/shortcuts.clj
@@ -12,7 +12,8 @@
 
 (def down? (atom false))
 (def ^:dynamic *hint-container* nil)
-(def ^:const mappings {:new-project "P"
+
+(def ^:const mappings (merge {:new-project "P"
                        :rename "M"
                        :import "O"
                        :remove "G"
@@ -45,7 +46,8 @@
                        :edit "shift M"
                        :open-in-browser "shift F"
                        :cancel "shift C"
-                       :build-console "shift A"})
+                       :build-console "shift A"}
+                      (try (read-string (slurp "keys.clj")) (catch Exception e {}))))
 
 (defn create-mapping!
   "Maps `func` to the key combo associated with `id`."


### PR DESCRIPTION
This is a proposition for [https://github.com/oakes/Nightcode/issues/61]

This allow to send the content of the selected text to the currently running REPL or the main REPL if none is running.
The shortcut is set to "1"
