### PR TITLE
Add support for eval top-level-expression

### DIFF
--- a/src/clojure/nightcode/builders.clj
+++ b/src/clojure/nightcode/builders.clj
@@ -59,11 +59,16 @@
          (.enterLine console))))
 
 (defn eval-selection!
+  "either the selected text wrapped in a do block or if no selection then the corresponding top level expression" 
   [console]
-  (some->> (editors/get-editor-selected-text)
-           utils/string->form
-           pr-str
-           (.enterLine console)))
+  (some->>
+    (or 
+      (some->>
+        (editors/get-editor-selected-text)
+        utils/string->form
+        pr-str)
+      (editors/get-tle-under-caret))
+    (.enterLine console)))
 
 ; toggling functions
 

--- a/src/clojure/nightcode/editors.clj
+++ b/src/clojure/nightcode/editors.clj
@@ -64,6 +64,18 @@
   (when-let [text-area (get-selected-text-area)]
     (.getSelectedText text-area)))
 
+(defn get-tle-under-caret
+  "finds the top-level-expression on caret and returns its code" 
+  []
+  (when-let [text-area (get-selected-text-area)]
+    (when-let [point (.getCaretPosition text-area)]
+      (->> 
+        (.getText text-area)
+        paredit.parser/parse 
+        paredit.loc-utils/parsed-root-loc 
+        (#(paredit.static-analysis/top-level-code-form % point)) 
+        paredit.loc-utils/loc-text
+        (#(clojure.string/replace % "\n" ""))))))
 ; tabs
 
 (def ^:dynamic *reorder-tabs?* true)


### PR DESCRIPTION
If there is a selection it just evals the selection as implemented until
now. 

Otherwise it uses paredit rules to figure out what the current
TLE is - and evaluates it.
