### PR TITLE
Sort completion suggestions lexographically

### DIFF
--- a/src/clojure/nightcode/completions.clj
+++ b/src/clojure/nightcode/completions.clj
@@ -50,6 +50,7 @@
                        (map #(get-clojure-completions prefix %))
                        flatten
                        set
+                       (sort-by :symbol-str)
                        (map #(create-completion this (:symbol-str %) (:doc-str %)))
                        doall)))
               (catch Exception _))


### PR DESCRIPTION
Not sure what the existing ordering for completions is based on but I always find it confusing. A lexicographical order might be simpler to understand.
