### PR TITLE
drop ansi codes in consoles text, kibit cleanup

### DIFF
--- a/src/clojure/nightcode/builders.clj
+++ b/src/clojure/nightcode/builders.clj
@@ -227,7 +227,7 @@ top level expression."
         widget-bar (ui/wrap-panel :items (map #(get widgets % %) *widgets*))]
     (utils/set-accessible-name! (.getTextArea console) :build-console)
     ; add the widget bar if necessary
-    (when (> (count *widgets*) 0)
+    (when (pos? (count *widgets*))
       (doto build-pane
         (s/config! :north widget-bar)
         shortcuts/create-hints!

--- a/src/clojure/nightcode/git.clj
+++ b/src/clojure/nightcode/git.clj
@@ -397,7 +397,7 @@
     (some-> @ui/root (update-paging-buttons! offset-atom)))
   ([panel offset-atom]
     (let [forward (s/select panel [:#git-forward])]
-      (s/config! forward :enabled? (> @offset-atom 0)))))
+      (s/config! forward :enabled? (pos? @offset-atom)))))
 
 (defn create-paging-buttons
   [offset-atom]
@@ -441,7 +441,7 @@
           ; create the bar that holds the widgets
           widget-bar (ui/wrap-panel :items (map #(get widgets % %) *widgets*))]
       ; add the widget bar if necessary
-      (when (> (count *widgets*) 0)
+      (when (pos? (count *widgets*))
         (doto git-pane
           (s/config! :north widget-bar)
           shortcuts/create-hints!

--- a/src/clojure/nightcode/logcat.clj
+++ b/src/clojure/nightcode/logcat.clj
@@ -75,7 +75,7 @@
           ; create the bar that holds the widgets
           widget-bar (ui/wrap-panel :items (map #(get widgets % %) *widgets*))]
       ; add the widget bar if necessary
-      (when (> (count *widgets*) 0)
+      (when (pos? (count *widgets*))
         (doto logcat-pane
           (s/config! :north widget-bar)
           shortcuts/create-hints!

--- a/src/clojure/nightcode/projects.clj
+++ b/src/clojure/nightcode/projects.clj
@@ -193,7 +193,7 @@
         widget-bar (ui/wrap-panel :items (map #(get widgets % %) *widgets*))]
     (utils/set-accessible-name! project-tree :project-tree)
     ; add the widget bar if necessary
-    (when (> (count *widgets*) 0)
+    (when (pos? (count *widgets*))
       (doto project-pane
         (s/config! :north widget-bar)
         shortcuts/create-hints!

--- a/src/clojure/nightcode/shortcuts.clj
+++ b/src/clojure/nightcode/shortcuts.clj
@@ -115,7 +115,7 @@
             ^BalloonTip tip (BalloonTip. view contents style false)
             view-height (.getHeight view)
             tip-height (.getHeight tip)
-            y (if (and (> view-height 0) vertically-centered?)
+            y (if (and (pos? view-height) vertically-centered?)
                 (-> (/ view-height 2)
                     (+ (/ tip-height 2))
                     (/ view-height))

--- a/src/clojure/nightcode/ui.clj
+++ b/src/clojure/nightcode/ui.clj
@@ -173,7 +173,7 @@
   [node children]
   (->> (for [child children]
          (get-node child))
-       (sort-by #(:name %))
+       (sort-by :name)
        (reduce-nodes node)
        vec))
 
@@ -246,5 +246,5 @@
     (when (nil? (.getSelectionPath tree))
       (.setSelectionRow tree 0))
     ; if the project tree is blank, reset atom so the buttons refresh
-    (when (= 0 (count @tree-projects))
+    (when (zero? (count @tree-projects))
       (reset! tree-selection nil))))

--- a/src/clojure/nightcode/utils.clj
+++ b/src/clojure/nightcode/utils.clj
@@ -205,7 +205,7 @@
 project-set."
   [project-set path]
   (let [f (io/file path)]
-    (when (and (= 0 (count (.listFiles f)))
+    (when (and (zero? (count (.listFiles f)))
                (not (contains? project-set path)))
       (io/delete-file f true)
       (->> f

--- a/src/java/nightcode/ui/JConsole.java
+++ b/src/java/nightcode/ui/JConsole.java
@@ -88,6 +88,8 @@ public class JConsole extends JScrollPane implements Runnable, KeyListener {
 
 	private final int SHOW_AMBIG_MAX = 10;
 
+	private final String ESCAPE_SEQ_PATTERN = "\u001B\\[[0-9;]*m";
+
 	// hack to prevent key repeat for some reason?
 	private boolean gotUp = true;
 
@@ -318,13 +320,14 @@ public class JConsole extends JScrollPane implements Runnable, KeyListener {
 		cmdStart = textLength();
 	}
 
-	private void append(String string) {
+	private void append(final String string) {
+		final String cleaned = string.replaceAll(ESCAPE_SEQ_PATTERN,"");
 		int slen = textLength();
 		text.select(slen, slen);
-		text.replaceSelection(string);
+		text.replaceSelection(cleaned);
 
 		try {
-			int overLength = slen + string.length() - HIST_MAX;
+			int overLength = slen + cleaned.length() - HIST_MAX;
 			if (overLength > 0) {
 				text.getDocument().remove(0, overLength);
 			}
@@ -415,12 +418,12 @@ public class JConsole extends JScrollPane implements Runnable, KeyListener {
 		text.repaint();
 	}
 
-	private void acceptLine(String line) {
+	private void acceptLine(final String line) {
 		if (outPipe == null) {
 			print("Console internal	error: cannot output ...", Color.red);
 		} else {
 			try {
-				outPipe.write(line);
+				outPipe.write(line.replaceAll(ESCAPE_SEQ_PATTERN,""));
 				outPipe.flush();
 			} catch (IOException e) {
 				outPipe = null;


### PR DESCRIPTION
Hi,

this contains 2 changes.

1.) I ran lein kibit (out of interest mostly) and implemented some of the suggestions, I can undo that if you don't want it.

2.) JConsole.java now drops ANSI escape codes (the suff thats make terminal font have colors), via Regex. 
Probably not perfect but usable with venantius/ultra "0.3.2".
See also https://github.com/oakes/Nightcode/issues/124 for examples.