### PR TITLE
Converted the Paredit cheat-sheet to a non-modal frame.  This allows …

### DIFF
--- a/src/clojure/nightcode/dialogs.clj
+++ b/src/clojure/nightcode/dialogs.clj
@@ -29,6 +29,42 @@
       s/show!)
   nil)
 
+
+(defn show-simple-table!
+  [text & {:keys [column-delimiter row-delimiter container title]
+           :or   {column-delimiter \,
+                  row-delimiter    \newline
+                  container        (s/frame)
+                  title            ""}}]
+  (let [table-markup
+        (str 
+          "<html>"
+          "<head>"
+          "<style type='text/css'>"
+            "tr {margin: 0px;}"
+            "tr {padding: 1px;}"
+            "td {padding: 0px 1px;}"
+          "</style>"
+          "</head>"
+          "<body>"
+            "<table>"
+              "<tr>"
+                "<td>"
+                 (-> text
+                   (string/replace (re-pattern (str column-delimiter)) "</td><td>")
+                   (string/replace (re-pattern (str row-delimiter))    "</td></tr><tr>"))
+              "</tr>"
+            "</table>"
+          "</body>"
+          "</html>")]
+    (-> container 
+       (s/config! :content table-markup :title title)
+        s/pack!
+        center!
+        stay-on-top!
+        s/show!)
+    nil))
+
 (defn show-native-dialog!
   [dir mode]
   (do (System/setProperty "apple.awt.fileDialogForDirectories" "true")

--- a/src/clojure/nightcode/editors.clj
+++ b/src/clojure/nightcode/editors.clj
@@ -25,6 +25,7 @@
 (def font-size (atom (max min-font-size (utils/read-pref :font-size 14))))
 (def paredit-enabled? (atom (utils/read-pref :enable-paredit false)))
 (def tabs (atom nil))
+(def paredit-help-frame (s/frame))
 
 ; basic getters
 
@@ -200,12 +201,17 @@
                       (apply concat)
                       (apply sorted-map-by compare))
         modifiers {"M" (utils/get-string :alt)
-                   "C" (utils/get-string :ctrl)}]
+                   "C" (utils/get-string :ctrl)}
+        frame-function (fn [text] 
+                         (dialogs/show-simple-table! text 
+                                   :container        paredit-help-frame
+                                   :column-delimiter " "
+                                   :title            "Paredit Keys"))]
     (->> (doseq [[k v] commands]
            (when-let [modifier (get modifiers (first k))]
-             (println modifier "+" (second k) " " (name v))))
+             (println modifier  "+" (second k) (name v))))
          with-out-str
-         dialogs/show-simple-dialog!)))
+         frame-function)))
 
 (defn focus-on-field!
   [id]


### PR DESCRIPTION
…the user to keep working on code without closing the cheat sheet.  The cheat-sheet is also now a table with lined-up columns for easier reading.

You'll notice that a persistent frame object is created at the head of editors.clj and passed to the show-simple-table function.  This way, clicking the ? (paredit cheat sheet) button again redisplays the current cheat-sheet frame rather than putting a second instance on the screen.