### PR TITLE
Fixing linux font rendering.

### DIFF
--- a/src/clj/nightcode/core.clj
+++ b/src/clj/nightcode/core.clj
@@ -74,6 +74,10 @@
       (.setSelected auto-save-button (:auto-save? @pref-state)))))
 
 (defn -main [& args]
+  (when (= "Linux" (System/getProperty "os.name"))
+    (do 
+      (System/setProperty "prism.lcdtext" "false")
+      (System/setProperty "prism.text" "t2k")))
   (swap! runtime-state assoc :web-port (e/start-web-server!))
   (Application/launch nightcode.core (into-array String args)))
 


### PR DESCRIPTION
Hi,
first of all thank you for your work on nightcode, it is a great tool that helped me learn clojure(I am still newbie when it comes to clojure). One thing that was bottering me on Nightcode was font rendering on linux(so called "rainbow" effect). I did some research and it seems to be known issue of JavaFX on linux. I found solution here: https://github.com/TomasMikula/RichTextFX/wiki/Known-Issues. Because it is simple setting of two properties I did it myself and I hope you can review my change, and merge it. 
With best regards,
Jakub
PS: I added some screenshots for comparison 

Fixed fonts in dark theme:
![darkfixed](https://cloud.githubusercontent.com/assets/1268108/25313920/3e34f700-2839-11e7-9647-0eaca64b3ae5.png)

Before fix in dark theme:
![defaultdark](https://cloud.githubusercontent.com/assets/1268108/25313921/3e38f3be-2839-11e7-9ab4-f7013c1e4b4f.png)

Before fix in light theme:
![defaultlight](https://cloud.githubusercontent.com/assets/1268108/25313922/3e3a94b2-2839-11e7-8a18-fdc350ab54b1.png)

Fixed fonts in light theme:
![lightfixed](https://cloud.githubusercontent.com/assets/1268108/25313923/3e425aee-2839-11e7-8c51-32669ba2a247.png)



